### PR TITLE
Initial renovate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# renovate-config
-Caluma preset configs for Renovate
+# Caluma Renovate Config Presets
+
+Caluma presets for [Renovate](https://github.com/singapore/renovate) tool.
+
+## Usage
+
+Add this into `renovate.json`:
+
+```json
+{
+  "extends": [
+    "github>projectcaluma/renovate-config"
+  ]
+}
+```
+
+## Useful Links
+
+- [Configuration Options](https://renovatebot.com/docs/configuration-options)
+- [Renovatebot Presets](https://github.com/renovatebot/presets/tree/master/packages)
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@projectcaluma/renovate-config",
+  "version": "0.0.0",
+  "description": "Caluma prest configs for Renovate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/projectcaluma/renovate-config.git"
+  },
+  "license": "MIT",
+  "author": "",
+  "keywords": ["caluma", "renovate", "config"],
+  "renovate-config": {
+    "default": {
+      "extends": ["config:base"],
+      "rangeStrategy": "pin",
+      "pip_requirements": {
+        "fileMatch": ["requirements.*txt$"],
+        "packageRules": [
+          {
+            "packageNames": ["django"],
+            "allowedVersions": "<1.12"
+          }
+        ]
+      },
+      "js": {
+        "packageRules": [
+          {
+            "packageNames": ["ember-cli", "ember-source"],
+            "allowedVersions": "<3.9"
+          }
+        ]
+      },
+      "docker": {
+        "packageRules": [
+          {
+            "packageNames": ["python"],
+            "allowedVersions": "3.6"
+          },
+          {
+            "packageNames": ["postgres"],
+            "allowedVersions": "9.6-alpine"
+          }
+        ],
+        "pinDigests": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Use dependency pinning as [recommend](https://renovatebot.com/docs/dependency-pinning/)
* Use docker digests as [recommend](https://renovatebot.com/docs/docker/)
* Restrict usage to Ember and Django LTS versions
* Pin Postgres to 9.6 as minimal Caluma requirement