### PR TITLE
Configure required status checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
     ],
     "pinDigests": true,
     "automergeType": "branch",
-    "automerge": true
+    "automerge": true,
+    "requiredStatusChecks": ["Travis+CI+-+Pull+Request"],
   }
 }


### PR DESCRIPTION
automerge only works if this is configured. For now only Travis but needs to check whether there is a difference.