### PR TITLE
Allow renovate to update to newest Django LTS release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "packageRules": [
       {
         "packageNames": ["django"],
-        "allowedVersions": "<1.12"
+        "allowedVersions": "<2.3"
       }
     ]
   },


### PR DESCRIPTION
Most likely newly opened Django update by renovate will need to be fixed.